### PR TITLE
feat: centralize configuration with zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "swagger-jsdoc": "^6.2.8",
                 "swagger-ui-express": "^5.0.1",
                 "typeorm": "^0.3.12",
-                "zod": "^4.1.4"
+                "zod": "^3.25.76"
             },
             "devDependencies": {
                 "@types/cookie-parser": "^1.4.9",
@@ -3315,9 +3315,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.4.tgz",
-            "integrity": "sha512-2YqJuWkU6IIK9qcE4k1lLLhyZ6zFw7XVRdQGpV97jEIZwTrscUw+DY31Xczd8nwaoksyJUIxCojZXwckJovWxA==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.12",
-        "zod": "^4.1.4"
+        "zod": "^3.25.76"
     },
     "devDependencies": {
         "@types/cookie-parser": "^1.4.9",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,27 @@
+import "dotenv/config";
+import { z } from "zod";
+
+const envSchema = z.object({
+  PORT: z.coerce.number().default(3000),
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  ACCESS_TOKEN_SECRET: z.string(),
+  REFRESH_TOKEN_SECRET: z.string(),
+  ACCESS_TOKEN_TTL: z.string().default("10m"),
+  REFRESH_TOKEN_TTL: z.string().default("7d"),
+  FRONTEND_ORIGIN: z.string(),
+  DB_HOST: z.string().default("localhost"),
+  DB_PORT: z.coerce.number().default(5432),
+  DB_USERNAME: z.string().default("your_db_username"),
+  DB_PASSWORD: z.string().default("your_db_password"),
+  DB_DATABASE: z.string().default("your_db_name"),
+});
+
+const _env = envSchema.safeParse(process.env);
+
+if (!_env.success) {
+  console.error("Invalid environment variables", _env.error.format());
+  throw new Error("Invalid environment variables");
+}
+
+export const config = _env.data;
+export type Config = z.infer<typeof envSchema>;

--- a/src/database.ts
+++ b/src/database.ts
@@ -9,14 +9,15 @@ import { WorkerHealthIncident } from "./entities/WorkerHealthIncident";
 import { Role } from "./entities/Role";
 import { Alert } from "./entities/Alert";
 import { Permission } from "./entities/Permission";
+import { config } from "./config";
 
 export const AppDataSource = new DataSource({
   type: "postgres",
-  host: process.env.DB_HOST || "localhost",
-  port: parseInt(process.env.DB_PORT || "5432"),
-  username: process.env.DB_USERNAME || "your_db_username",
-  password: process.env.DB_PASSWORD || "your_db_password",
-  database: process.env.DB_DATABASE || "your_db_name",
+  host: config.DB_HOST,
+  port: config.DB_PORT,
+  username: config.DB_USERNAME,
+  password: config.DB_PASSWORD,
+  database: config.DB_DATABASE,
   synchronize: false,
   logging: false,
   entities: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,17 @@
-import "dotenv/config";
 import "reflect-metadata";
 import app from "./app";
 import { AppDataSource } from "./database";
+import { config } from "./config";
 
-const PORT = process.env.PORT || 3000;
+const PORT = config.PORT;
 
 app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
+  console.log(`Server is running on port ${PORT}`);
 });
 
 AppDataSource.initialize()
   .then(() => {
-      // TODO: later i should have app init here
+    // TODO: later i should have app init here
   })
   .catch((error) => {
     console.error("Error during Data Source initialization", error);


### PR DESCRIPTION
## Summary
- add typed config module using zod to parse env vars
- use config for server port and database connection
- pin zod to v3 for TS 4.x compatibility

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b04f7ea0f8832083efd28d869a96c7