### PR TITLE
feat: add user entity and migration

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -9,6 +9,7 @@ import { WorkerHealthIncident } from "./entities/WorkerHealthIncident";
 import { Role } from "./entities/Role";
 import { Alert } from "./entities/Alert";
 import { Permission } from "./entities/Permission";
+import { User } from "./entities/User";
 import { config } from "./config";
 
 export const AppDataSource = new DataSource({
@@ -30,7 +31,8 @@ export const AppDataSource = new DataSource({
     WorkerHealthIncident,
     Role,
     Alert,
-    Permission
+    Permission,
+    User
   ],
   migrations: ["src/migrations/*.ts"],
   migrationsRun: true

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from "typeorm";
+import { Role } from "./Role";
+
+@Entity({ name: "users" })
+export class User {
+  @PrimaryGeneratedColumn()
+  user_id!: number;
+
+  @Column({ type: "varchar", length: 100, unique: true })
+  email!: string;
+
+  @Column({ type: "varchar", length: 255 })
+  password_hash!: string;
+
+  @Column({ type: "int", default: 0 })
+  token_version!: number;
+
+  @Column({ type: "int", nullable: true })
+  role_id?: number | null;
+
+  @ManyToOne(() => Role, { onDelete: "SET NULL" })
+  @JoinColumn({ name: "role_id" })
+  role?: Role | null;
+}
+

--- a/src/migrations/1756406403527-add_user.ts
+++ b/src/migrations/1756406403527-add_user.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUser1756406403527 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "users" (
+        "user_id" SERIAL NOT NULL,
+        "email" character varying(100) NOT NULL,
+        "password_hash" character varying(255) NOT NULL,
+        "token_version" integer NOT NULL DEFAULT 0,
+        "role_id" integer,
+        CONSTRAINT "PK_users_user_id" PRIMARY KEY ("user_id")
+      )
+    `);
+    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_users_email" ON "users" ("email")`);
+    await queryRunner.query(`ALTER TABLE "users" ADD CONSTRAINT "FK_users_role_id" FOREIGN KEY ("role_id") REFERENCES "roles"("role_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP CONSTRAINT "FK_users_role_id"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_users_email"`);
+    await queryRunner.query(`DROP TABLE "users"`);
+  }
+}


### PR DESCRIPTION
## Summary
- add User entity
- register User entity in data source
- add migration for users table with unique email

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npm run migration:generate --name=add_user` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a23eaa58832096b449c7ccbf4425