### PR TITLE
feat: add refresh token entity

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -10,6 +10,7 @@ import { Role } from "./entities/Role";
 import { Alert } from "./entities/Alert";
 import { Permission } from "./entities/Permission";
 import { User } from "./entities/User";
+import { RefreshToken } from "./entities/RefreshToken";
 import { config } from "./config";
 
 export const AppDataSource = new DataSource({
@@ -32,7 +33,8 @@ export const AppDataSource = new DataSource({
     Role,
     Alert,
     Permission,
-    User
+    User,
+    RefreshToken
   ],
   migrations: ["src/migrations/*.ts"],
   migrationsRun: true

--- a/src/entities/RefreshToken.ts
+++ b/src/entities/RefreshToken.ts
@@ -1,0 +1,30 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from "typeorm";
+import { User } from "./User";
+
+@Entity({ name: "refresh_tokens" })
+export class RefreshToken {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", unique: true })
+  jti!: string;
+
+  @Column({ type: "varchar", length: 255 })
+  hashedToken!: string;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+
+  @Column({ type: "boolean", default: false })
+  revoked!: boolean;
+
+  @Column({ type: "varchar", nullable: true })
+  replacedBy?: string | null;
+
+  @Column({ type: "timestamptz" })
+  expiresAt!: Date;
+
+  @Column({ type: "timestamptz", default: () => "CURRENT_TIMESTAMP" })
+  createdAt!: Date;
+}

--- a/src/migrations/1756406770370-add_refresh_token.ts
+++ b/src/migrations/1756406770370-add_refresh_token.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRefreshToken1756406770370 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "refresh_tokens" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "jti" character varying NOT NULL,
+        "hashed_token" character varying(255) NOT NULL,
+        "revoked" boolean NOT NULL DEFAULT false,
+        "replaced_by" character varying,
+        "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "user_id" integer,
+        CONSTRAINT "PK_refresh_tokens_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_refresh_tokens_jti" ON "refresh_tokens" ("jti")`);
+    await queryRunner.query(`ALTER TABLE "refresh_tokens" ADD CONSTRAINT "FK_refresh_tokens_user_id" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "refresh_tokens" DROP CONSTRAINT "FK_refresh_tokens_user_id"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_refresh_tokens_jti"`);
+    await queryRunner.query(`DROP TABLE "refresh_tokens"`);
+  }
+}


### PR DESCRIPTION
## Summary
- create RefreshToken entity for storing refresh tokens
- wire RefreshToken into data source
- add migration for refresh_tokens table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot parse zod v4 type definitions with TypeScript 4.6)*
- `npm run migration:generate --name=add_refresh_token` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3b8ff7083209864f90d1561d397