### PR TITLE
Add JWT and token utility functions

### DIFF
--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -1,0 +1,8 @@
+export interface AccessTokenPayload {
+  sub: number;
+  tv: number;
+}
+
+export interface RefreshTokenPayload extends AccessTokenPayload {
+  jti: string;
+}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,50 @@
+import jwt from "jsonwebtoken";
+import { config } from "../config";
+import { AccessTokenPayload, RefreshTokenPayload } from "../types/token";
+import { User } from "../entities/User";
+
+/**
+ * Sign an access token with a 10 minute expiry.
+ */
+export function signAccessToken(user: Pick<User, "user_id" | "token_version">): string {
+  const payload: AccessTokenPayload = {
+    sub: user.user_id,
+    tv: user.token_version,
+  };
+
+  return jwt.sign(payload, config.ACCESS_TOKEN_SECRET, {
+    expiresIn: "10m",
+  });
+}
+
+/**
+ * Sign a refresh token with a 7 day expiry.
+ */
+export function signRefreshToken(
+  user: Pick<User, "user_id" | "token_version">,
+  jti: string
+): string {
+  const payload: RefreshTokenPayload = {
+    sub: user.user_id,
+    tv: user.token_version,
+    jti,
+  };
+
+  return jwt.sign(payload, config.REFRESH_TOKEN_SECRET, {
+    expiresIn: "7d",
+  });
+}
+
+/**
+ * Verify an access token and return its payload.
+ */
+export function verifyAccessToken(token: string): AccessTokenPayload {
+  return jwt.verify(token, config.ACCESS_TOKEN_SECRET) as AccessTokenPayload;
+}
+
+/**
+ * Verify a refresh token and return its payload.
+ */
+export function verifyRefreshToken(token: string): RefreshTokenPayload {
+  return jwt.verify(token, config.REFRESH_TOKEN_SECRET) as RefreshTokenPayload;
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,0 +1,35 @@
+import { createHash } from "crypto";
+import { Response } from "express";
+import { config } from "../config";
+
+const REFRESH_COOKIE_NAME = "refreshToken";
+const REFRESH_COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: "strict" as const,
+  secure: config.NODE_ENV === "production",
+  path: "/",
+};
+
+/**
+ * Hash a token using SHA-256.
+ */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Set the refresh token cookie on the response.
+ */
+export function setRefreshCookie(res: Response, token: string): void {
+  res.cookie(REFRESH_COOKIE_NAME, token, {
+    ...REFRESH_COOKIE_OPTIONS,
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+  });
+}
+
+/**
+ * Clear the refresh token cookie from the response.
+ */
+export function clearRefreshCookie(res: Response): void {
+  res.clearCookie(REFRESH_COOKIE_NAME, REFRESH_COOKIE_OPTIONS);
+}


### PR DESCRIPTION
## Summary
- add JWT helpers for signing and verifying access/refresh tokens
- add token hashing and refresh token cookie utilities
- define shared types for JWT payloads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TypeScript errors in node_modules/zod)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a6274368832087fda74591a09e1d