### PR TITLE
Add CSRF protection to refresh token flow

### DIFF
--- a/src/utils/csrf.ts
+++ b/src/utils/csrf.ts
@@ -1,0 +1,47 @@
+import { randomBytes } from "crypto";
+import { Request, Response } from "express";
+import { config } from "../config";
+
+export const CSRF_COOKIE_NAME = "csrfToken";
+export const CSRF_COOKIE_OPTIONS = {
+  httpOnly: false,
+  sameSite: "strict" as const,
+  secure: config.NODE_ENV === "production",
+  path: "/",
+};
+
+/**
+ * Generate a random CSRF secret.
+ */
+export function createCsrfSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Set the CSRF cookie on the response.
+ */
+export function setCsrfCookie(res: Response, secret: string): void {
+  res.cookie(CSRF_COOKIE_NAME, secret, CSRF_COOKIE_OPTIONS);
+}
+
+/**
+ * Clear the CSRF cookie from the response.
+ */
+export function clearCsrfCookie(res: Response): void {
+  res.clearCookie(CSRF_COOKIE_NAME, CSRF_COOKIE_OPTIONS);
+}
+
+/**
+ * Validate the CSRF token from the request header and cookie.
+ */
+export function validateCsrf(req: Request): boolean {
+  const headerToken = req.headers["x-csrf"];
+  if (typeof headerToken !== "string") {
+    return false;
+  }
+  const cookieToken = req.cookies?.[CSRF_COOKIE_NAME];
+  if (typeof cookieToken !== "string") {
+    return false;
+  }
+  return headerToken === cookieToken;
+}


### PR DESCRIPTION
## Summary
- add CSRF utility for generating secrets, setting/clearing cookies and validating requests
- set refresh token cookie with SameSite=None and pair it with CSRF cookie
- validate refresh requests using CSRF cookie/header comparison

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: src/utils/jwt.ts(42,10): error TS2352: Conversion of type 'string | JwtPayload' to type 'AccessTokenPayload' may be a mistake because neither type sufficiently overlaps with the other. Property 'tv' is missing in type 'JwtPayload' but required in type 'AccessTokenPayload'. src/utils/jwt.ts(49,10): error TS2352: Conversion of type 'string | JwtPayload' to type 'RefreshTokenPayload' may be a mistake because neither type sufficiently overlaps with the other. Property 'tv' is missing in type 'JwtPayload' but required in type 'RefreshTokenPayload'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd9b15208320aa078eefd74556b0