### PR TITLE
feat: add token service

### DIFF
--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -1,0 +1,65 @@
+import { AppDataSource } from "../database";
+import { RefreshToken } from "../entities/RefreshToken";
+import { User } from "../entities/User";
+import { hashToken } from "../utils/token";
+
+const refreshTokenRepository = AppDataSource.getRepository(RefreshToken);
+const userRepository = AppDataSource.getRepository(User);
+
+/**
+ * Create a refresh token record with a hashed token.
+ */
+export async function createRefreshToken(
+  user: User,
+  token: string,
+  jti: string
+): Promise<RefreshToken> {
+  const refreshToken = refreshTokenRepository.create({
+    jti,
+    hashedToken: hashToken(token),
+    user,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  });
+
+  return refreshTokenRepository.save(refreshToken);
+}
+
+/**
+ * Find a refresh token by its JWT ID (jti).
+ */
+export async function findTokenByJti(jti: string): Promise<RefreshToken | null> {
+  return refreshTokenRepository.findOne({ where: { jti } });
+}
+
+/**
+ * Revoke a single refresh token.
+ */
+export async function revokeToken(
+  tokenId: string,
+  replacedBy?: string
+): Promise<void> {
+  await refreshTokenRepository.update({ id: tokenId }, {
+    revoked: true,
+    replacedBy: replacedBy ?? null,
+  });
+}
+
+/**
+ * Revoke all refresh tokens belonging to a user. Useful on logout or token reuse.
+ */
+export async function revokeUserTokens(userId: number): Promise<void> {
+  await refreshTokenRepository
+    .createQueryBuilder()
+    .update()
+    .set({ revoked: true })
+    .where("user_id = :userId", { userId })
+    .execute();
+}
+
+/**
+ * Increment a user's token version, invalidating existing tokens.
+ */
+export async function bumpTokenVersion(userId: number): Promise<void> {
+  await userRepository.increment({ user_id: userId }, "token_version", 1);
+}
+

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -39,12 +39,12 @@ export function signRefreshToken(
  * Verify an access token and return its payload.
  */
 export function verifyAccessToken(token: string): AccessTokenPayload {
-  return jwt.verify(token, config.ACCESS_TOKEN_SECRET) as AccessTokenPayload;
+  return jwt.verify(token, config.ACCESS_TOKEN_SECRET) as unknown as AccessTokenPayload;
 }
 
 /**
  * Verify a refresh token and return its payload.
  */
 export function verifyRefreshToken(token: string): RefreshTokenPayload {
-  return jwt.verify(token, config.REFRESH_TOKEN_SECRET) as RefreshTokenPayload;
+  return jwt.verify(token, config.REFRESH_TOKEN_SECRET) as unknown as RefreshTokenPayload;
 }


### PR DESCRIPTION
## Summary
- implement refresh token service for creation, revocation, lookup, and token version bumping
- fix jwt verification casts for TypeScript

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf9239ec8320a445cef4c4eb6288