### PR TITLE
Add auth middleware for bearer tokens

### DIFF
--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from "express";
+import { AppDataSource } from "../database";
+import { User } from "../entities/User";
+import { verifyAccessToken } from "../utils/jwt";
+
+export async function requireAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const authHeader = req.headers["authorization"];
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const token = authHeader.slice(7).trim();
+
+  try {
+    const payload = verifyAccessToken(token);
+    const userRepository = AppDataSource.getRepository(User);
+    const user = await userRepository.findOne({
+      where: { user_id: payload.sub },
+      relations: ["role", "role.permissions"],
+    });
+
+    if (!user || user.token_version !== payload.tv) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    req.user = user as any;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `requireAuth` middleware to validate bearer tokens and attach the user

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1d669095c8320aeb0435e099f477e