### PR TITLE
feat: add authentication endpoints

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import cookieParser from "cookie-parser";
 import workerRoutes from "./routes/worker.routes";
 // Import other routes similarly:
 import deviceRoutes from "./routes/device.routes";
@@ -17,6 +18,7 @@ import { errorHandler } from "./middleware/errorHandler";
 const app = express();
 
 app.use(express.json());
+app.use(cookieParser());
 
 app.use("/api-docs", swaggerServe, swaggerSetup);
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,131 @@
+import { Request, Response } from "express";
+import bcrypt from "bcryptjs";
+import { randomUUID } from "crypto";
+import { AppDataSource } from "../database";
+import { User } from "../entities/User";
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyRefreshToken,
+} from "../utils/jwt";
+import {
+  setRefreshCookie,
+  clearRefreshCookie,
+  getRefreshToken,
+  hashToken,
+} from "../utils/token";
+import {
+  createRefreshToken,
+  findTokenByJti,
+  revokeToken,
+  revokeUserTokens,
+  bumpTokenVersion,
+} from "../services/token.service";
+
+const userRepository = AppDataSource.getRepository(User);
+
+export const register = async (req: Request, res: Response) => {
+  try {
+    const { email, password } = req.body as {
+      email: string;
+      password: string;
+    };
+
+    const password_hash = await bcrypt.hash(password, 12);
+    const user = userRepository.create({ email, password_hash });
+    const saved = await userRepository.save(user);
+    return res
+      .status(201)
+      .json({ id: saved.user_id, email: saved.email });
+  } catch (err) {
+    return res.status(400).json({ error: "Unable to register" });
+  }
+};
+
+export const login = async (req: Request, res: Response) => {
+  const { email, password } = req.body as {
+    email: string;
+    password: string;
+  };
+
+  const user = await userRepository.findOne({ where: { email } });
+  if (!user) {
+    return res.status(401).json({ error: "Invalid credentials" });
+  }
+
+  const valid = await bcrypt.compare(password, user.password_hash);
+  if (!valid) {
+    return res.status(401).json({ error: "Invalid credentials" });
+  }
+
+  const jti = randomUUID();
+  const accessToken = signAccessToken(user);
+  const refreshToken = signRefreshToken(user, jti);
+  await createRefreshToken(user, refreshToken, jti);
+  setRefreshCookie(res, refreshToken);
+
+  return res.json({
+    accessToken,
+    user: { id: user.user_id, email: user.email },
+  });
+};
+
+export const refresh = async (req: Request, res: Response) => {
+  const token = getRefreshToken(req);
+  if (!token) {
+    clearRefreshCookie(res);
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const payload = verifyRefreshToken(token);
+    const stored = await findTokenByJti(payload.jti);
+    if (
+      !stored ||
+      stored.revoked ||
+      stored.expiresAt < new Date() ||
+      stored.hashedToken !== hashToken(token)
+    ) {
+      clearRefreshCookie(res);
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const user = await userRepository.findOne({
+      where: { user_id: payload.sub },
+    });
+    if (!user || user.token_version !== payload.tv) {
+      clearRefreshCookie(res);
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const newJti = randomUUID();
+    const accessToken = signAccessToken(user);
+    const newRefreshToken = signRefreshToken(user, newJti);
+    const newRecord = await createRefreshToken(
+      user,
+      newRefreshToken,
+      newJti
+    );
+    await revokeToken(stored.id, newRecord.id);
+    setRefreshCookie(res, newRefreshToken);
+
+    return res.json({ accessToken });
+  } catch (err) {
+    clearRefreshCookie(res);
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+};
+
+export const logout = async (req: Request, res: Response) => {
+  const user = req.user! as any;
+  await revokeUserTokens(user.user_id);
+  await bumpTokenVersion(user.user_id);
+  clearRefreshCookie(res);
+  return res.json({ ok: true });
+};
+
+export const me = (req: Request, res: Response) => {
+  const user = req.user! as any;
+  return res.json({ id: user.user_id, email: user.email });
+};
+

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,15 +1,20 @@
 import { Router } from "express";
 import { loginLimiter, refreshLimiter } from "../middleware/rateLimit";
+import { requireAuth } from "../middleware/requireAuth";
+import {
+  register,
+  login,
+  refresh,
+  logout,
+  me,
+} from "../controllers/auth.controller";
 
 const router = Router();
 
-router.post("/login", loginLimiter, (req, res) => {
-  res.status(200).json({ message: "login" });
-});
-
-router.post("/refresh", refreshLimiter, (req, res) => {
-  res.status(200).json({ message: "refresh" });
-});
+router.post("/register", register);
+router.post("/login", loginLimiter, login);
+router.post("/refresh", refreshLimiter, refresh);
+router.post("/logout", requireAuth, logout);
+router.get("/me", requireAuth, me);
 
 export default router;
-


### PR DESCRIPTION
## Summary
- implement auth controller with register, login, token refresh, logout, and me endpoints
- wire up auth routes and cookie parsing middleware

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b1dd4ec5fc8320b6ae1199e333d046