### PR TITLE
Add auth routes with CSRF validation and mount at /auth

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ app.use("/api/health-incidents", healthIncidentRoutes);
 app.use("/api/permissions", permissionRoutes);
 app.use("/api/roles", roleRoutes);
 app.use("/api/alerts", alertRoutes);
-app.use("/api/auth", authRoutes);
+app.use("/auth", authRoutes);
 
 app.use(errorHandler);
 

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { loginLimiter, refreshLimiter } from "../middleware/rateLimit";
 import { requireAuth } from "../middleware/requireAuth";
 import {
@@ -8,12 +8,24 @@ import {
   logout,
   me,
 } from "../controllers/auth.controller";
+import { validateCsrf } from "../utils/csrf";
 
 const router = Router();
 
+const csrfValidation = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!validateCsrf(req)) {
+    return res.status(403).json({ error: "Invalid CSRF token" });
+  }
+  next();
+};
+
 router.post("/register", register);
 router.post("/login", loginLimiter, login);
-router.post("/refresh", refreshLimiter, refresh);
+router.post("/refresh", refreshLimiter, csrfValidation, refresh);
 router.post("/logout", requireAuth, logout);
 router.get("/me", requireAuth, me);
 


### PR DESCRIPTION
## Summary
- add auth routes for register/login/refresh/logout/me with rate limits and CSRF validation for refresh
- mount auth routes at `/auth` in the Express app

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1de526b748320b84f315f321f815d