### PR TITLE
feat: secure cookies and enable CORS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
             },
             "devDependencies": {
                 "@types/cookie-parser": "^1.4.9",
+                "@types/cors": "^2.8.19",
                 "@types/express": "^4.17.13",
                 "@types/express-rate-limit": "^6.0.2",
                 "@types/jsonwebtoken": "^9.0.10",
@@ -399,6 +400,16 @@
             "license": "MIT",
             "peerDependencies": {
                 "@types/express": "*"
+            }
+        },
+        "node_modules/@types/cors": {
+            "version": "2.8.19",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+            "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/express": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     },
     "devDependencies": {
         "@types/cookie-parser": "^1.4.9",
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.13",
         "@types/express-rate-limit": "^6.0.2",
         "@types/jsonwebtoken": "^9.0.10",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,8 @@
 import express from "express";
 import cookieParser from "cookie-parser";
+import cors from "cors";
+import helmet from "helmet";
+import { config } from "./config";
 import workerRoutes from "./routes/worker.routes";
 // Import other routes similarly:
 import deviceRoutes from "./routes/device.routes";
@@ -19,6 +22,8 @@ const app = express();
 
 app.use(express.json());
 app.use(cookieParser());
+app.use(helmet());
+app.use(cors({ origin: config.FRONTEND_ORIGIN, credentials: true }));
 
 app.use("/api-docs", swaggerServe, swaggerSetup);
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -11,9 +11,9 @@ import {
 const REFRESH_COOKIE_NAME = "refreshToken";
 const REFRESH_COOKIE_OPTIONS = {
   httpOnly: true,
-  sameSite: "none" as const,
+  sameSite: "lax" as const,
   secure: config.NODE_ENV === "production",
-  path: "/",
+  path: "/auth/refresh",
 };
 
 /**


### PR DESCRIPTION
## Summary
- add helmet and configure CORS using FRONTEND_ORIGIN with credentials
- ensure refresh cookie is httpOnly, same-site lax, and secure in production at /auth/refresh
- include @types/cors for TypeScript build

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ecabf7d48320a7912ce33c5e96d8