### PR TITLE
Use configuration-based token expirations

### DIFF
--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -1,7 +1,8 @@
 import { AppDataSource } from "../database";
 import { RefreshToken } from "../entities/RefreshToken";
 import { User } from "../entities/User";
-import { hashToken } from "../utils/token";
+import { config } from "../config";
+import { hashToken, ttlToMs } from "../utils/token";
 
 const refreshTokenRepository = AppDataSource.getRepository(RefreshToken);
 const userRepository = AppDataSource.getRepository(User);
@@ -18,7 +19,7 @@ export async function createRefreshToken(
     jti,
     hashedToken: hashToken(token),
     user,
-    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    expiresAt: new Date(Date.now() + ttlToMs(config.REFRESH_TOKEN_TTL)),
   });
 
   return refreshTokenRepository.save(refreshToken);

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,10 +1,11 @@
 import jwt from "jsonwebtoken";
+import type { StringValue } from "ms";
 import { config } from "../config";
 import { AccessTokenPayload, RefreshTokenPayload } from "../types/token";
 import { User } from "../entities/User";
 
 /**
- * Sign an access token with a 10 minute expiry.
+ * Sign an access token with the configured expiry.
  */
 export function signAccessToken(user: Pick<User, "user_id" | "token_version">): string {
   const payload: AccessTokenPayload = {
@@ -13,12 +14,12 @@ export function signAccessToken(user: Pick<User, "user_id" | "token_version">): 
   };
 
   return jwt.sign(payload, config.ACCESS_TOKEN_SECRET, {
-    expiresIn: "10m",
+    expiresIn: config.ACCESS_TOKEN_TTL as StringValue,
   });
 }
 
 /**
- * Sign a refresh token with a 7 day expiry.
+ * Sign a refresh token with the configured expiry.
  */
 export function signRefreshToken(
   user: Pick<User, "user_id" | "token_version">,
@@ -31,7 +32,7 @@ export function signRefreshToken(
   };
 
   return jwt.sign(payload, config.REFRESH_TOKEN_SECRET, {
-    expiresIn: "7d",
+    expiresIn: config.REFRESH_TOKEN_TTL as StringValue,
   });
 }
 


### PR DESCRIPTION
## Summary
- derive JWT expiration from configuration instead of hard-coded values
- compute refresh token database expiry and cookie maxAge from config TTL
- add utility to convert TTL strings to milliseconds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5bd33e8e4832091632cac005a38d5