### PR TITLE
Expand user typings and clean controller casts

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -130,7 +130,7 @@ export const refresh = async (req: Request, res: Response) => {
 };
 
 export const logout = async (req: Request, res: Response) => {
-  const user = req.user! as any;
+  const user = req.user!;
   await revokeUserTokens(user.user_id);
   await bumpTokenVersion(user.user_id);
   clearRefreshCookie(res);
@@ -138,7 +138,7 @@ export const logout = async (req: Request, res: Response) => {
 };
 
 export const me = (req: Request, res: Response) => {
-  const user = req.user! as any;
+  const user = req.user!;
   return res.json({ id: user.user_id, email: user.email });
 };
 

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -27,7 +27,7 @@ export async function requireAuth(
       return res.status(401).json({ error: "Unauthorized" });
     }
 
-    req.user = user as any;
+    req.user = user;
     next();
   } catch (err) {
     return res.status(401).json({ error: "Unauthorized" });

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,9 +1,9 @@
-import type { User } from "./user";
+import type { User as AuthUser } from "./user";
 
 declare global {
   namespace Express {
     interface Request {
-      user?: User;
+      user?: AuthUser;
     }
   }
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,11 +1,24 @@
 export interface Permission {
+  permission_id: number;
   name: string;
+  description?: string | null;
 }
 
 export interface Role {
+  role_id: number;
+  role_name: string;
+  description?: string | null;
+  max_pulse?: number | null;
+  max_gas_exposure?: number | null;
+  max_inactivity?: number | null;
   permissions: Permission[];
 }
 
 export interface User {
-  role: Role;
+  user_id: number;
+  email: string;
+  password_hash: string;
+  token_version: number;
+  role_id?: number | null;
+  role?: Role | null;
 }


### PR DESCRIPTION
## Summary
- Expand user-related TypeScript interfaces to include IDs, email, token_version, role, and permission details
- Update Express request typing to use richer user interface
- Remove `as any` usage in auth controller and middleware, relying on strongly typed `req.user`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce45258c8320b281d1837dcbd8d8