### PR TITLE
Add custom rate limit handler for JSON responses

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,4 +1,16 @@
-import rateLimit from "express-rate-limit";
+import rateLimit, { Options } from "express-rate-limit";
+import { Request, Response, NextFunction } from "express";
+
+const handler = (
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+  options: Options
+) => {
+  const message =
+    typeof options.message === "string" ? options.message : "Too many requests";
+  res.status(429).json({ error: message });
+};
 
 export const loginLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -6,6 +18,7 @@ export const loginLimiter = rateLimit({
   message: "Too many login attempts, please try again later.",
   standardHeaders: true,
   legacyHeaders: false,
+  handler,
 });
 
 export const refreshLimiter = rateLimit({
@@ -14,5 +27,6 @@ export const refreshLimiter = rateLimit({
   message: "Too many token requests, please try again later.",
   standardHeaders: true,
   legacyHeaders: false,
+  handler,
 });
 


### PR DESCRIPTION
## Summary
- add express-rate-limit handler returning 429 and JSON error message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5d11752b88320b56c4fcae2ca431c