### PR TITLE
Normalize bearer auth scheme

### DIFF
--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -9,11 +9,10 @@ export async function requireAuth(
   next: NextFunction
 ) {
   const authHeader = req.headers["authorization"];
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+  const [scheme, token] = (authHeader ?? "").split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
     return res.status(401).json({ error: "Unauthorized" });
   }
-
-  const token = authHeader.slice(7).trim();
 
   try {
     const payload = verifyAccessToken(token);


### PR DESCRIPTION
## Summary
- ensure Authorization scheme check is case-insensitive and token-based

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d3cf9f90832083329962045819b7