### PR TITLE
feat: protect private routes with authentication

### DIFF
--- a/src/routes/alert.routes.ts
+++ b/src/routes/alert.routes.ts
@@ -8,8 +8,11 @@ import {
 } from "../controllers/alert.controller";
 import { AlertType } from "../entities/Alert";
 import { validateEnum } from "../middleware/enumValidation.middleware";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/assignment.routes.ts
+++ b/src/routes/assignment.routes.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getAssignments, getAssignmentById, createAssignment, updateAssignment, deleteAssignment } from "../controllers/assignment.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/device.routes.ts
+++ b/src/routes/device.routes.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getDevices, getDeviceById, createDevice, updateDevice, deleteDevice } from "../controllers/device.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/healthCondition.routes.ts
+++ b/src/routes/healthCondition.routes.ts
@@ -8,8 +8,11 @@ import {
 } from "../controllers/healthCondition.controller";
 import { SeverityLevel, ConditionStatus } from "../entities/WorkerHealthCondition";
 import { validateEnum } from "../middleware/enumValidation.middleware";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/healthIncident.routes.ts
+++ b/src/routes/healthIncident.routes.ts
@@ -8,8 +8,11 @@ import {
 } from "../controllers/healthIncident.controller";
 import { SeverityLevel } from "../entities/WorkerHealthCondition";
 import { validateEnum } from "../middleware/enumValidation.middleware";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/permission.routes.ts
+++ b/src/routes/permission.routes.ts
@@ -6,8 +6,11 @@ import {
   updatePermission,
   deletePermission,
 } from "../controllers/permission.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/role.routes.ts
+++ b/src/routes/role.routes.ts
@@ -6,8 +6,11 @@ import {
   updateRole,
   deleteRole,
 } from "../controllers/role.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/sensorReading.routes.ts
+++ b/src/routes/sensorReading.routes.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getSensorReadings, createSensorReading } from "../controllers/sensorReading.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/shift.routes.ts
+++ b/src/routes/shift.routes.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getShifts, getShiftById, createShift, updateShift, deleteShift } from "../controllers/shift.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi

--- a/src/routes/worker.routes.ts
+++ b/src/routes/worker.routes.ts
@@ -6,8 +6,11 @@ import {
   updateWorker,
   deleteWorker,
 } from "../controllers/worker.controller";
+import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
+
+router.use(requireAuth);
 
 /**
  * @openapi


### PR DESCRIPTION
## Summary
- apply `requireAuth` to all non-auth route modules
- ensure public auth endpoints remain accessible

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d82bc5248320a300c125386b1b0f