### PR TITLE
docs: translate auth section to Persian

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,25 @@
-# Sample environment variables for the application
+# نمونه متغیرهای محیطی برای برنامه
 
-# Environment
-# NODE_ENV can be "development", "test", or "production"
-NODE_ENV=development # Set to "production" in production
+# محیط اجرا
+# NODE_ENV می‌تواند "development"، "test" یا "production" باشد
+NODE_ENV=development # در محیط تولید مقدار "production" قرار دهید
 
-# Server configuration
+# پیکربندی سرور
 PORT=3000
 FRONTEND_ORIGIN=http://localhost:3000
 
-# Database configuration
+# پیکربندی پایگاه داده
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=your_db_username
 DB_PASSWORD=your_db_password
 DB_DATABASE=your_db_name
 
-# JWT configuration
+# پیکربندی JWT
 ACCESS_TOKEN_SECRET=your_access_token_secret
 REFRESH_TOKEN_SECRET=your_refresh_token_secret
 ACCESS_TOKEN_TTL=10m
 REFRESH_TOKEN_TTL=7d
 
-# Migrations
-# Run `npm run migration:run` after applying schema changes
+# مهاجرت‌ها
+# پس از اعمال تغییرات در مدل‌ها دستور `npm run migration:run` را اجرا کنید


### PR DESCRIPTION
## Summary
- localize auth and token management docs into Persian
- expand env setup section with token variables
- translate `.env.example` comments to Persian

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b03625e1388320b88b7ac4c0dd4019