### PR TITLE
feat: add postman environment templates

### DIFF
--- a/docs/api/postman_env.dev.json
+++ b/docs/api/postman_env.dev.json
@@ -1,0 +1,27 @@
+{
+  "id": "d757c054-991f-49a9-a632-a34e22602a02",
+  "name": "Development",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bearerToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "csrfToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-09-02T16:58:40Z",
+  "_postman_exported_using": "Postman/10.17.7"
+}

--- a/docs/api/postman_env.prod.json
+++ b/docs/api/postman_env.prod.json
@@ -1,0 +1,27 @@
+{
+  "id": "8dc7bbb0-a650-4f90-b7fa-cced6839d5fb",
+  "name": "Production",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.example.com",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bearerToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "csrfToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-09-02T16:58:40Z",
+  "_postman_exported_using": "Postman/10.17.7"
+}

--- a/docs/api/postman_env.staging.json
+++ b/docs/api/postman_env.staging.json
@@ -1,0 +1,27 @@
+{
+  "id": "993e8f4b-231b-47bc-8bb7-cfe33c9f2263",
+  "name": "Staging",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "https://staging.example.com",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bearerToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "csrfToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-09-02T16:58:40Z",
+  "_postman_exported_using": "Postman/10.17.7"
+}


### PR DESCRIPTION
## Summary
- add development, staging and production Postman env templates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: File '/workspace/karsu-backend/scripts/swagger-validate.ts' is not under 'rootDir' '/workspace/karsu-backend/src')

------
https://chatgpt.com/codex/tasks/task_e_68b721f36d348320b5f26043d172128e