### PR TITLE
ensure public auth endpoints skip bearer auth

### DIFF
--- a/docs/api/postman_collection.json
+++ b/docs/api/postman_collection.json
@@ -55,6 +55,9 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"strongPassword123\"\n}"
+            },
+            "auth": {
+              "type": "noauth"
             }
           },
           "response": [
@@ -4792,6 +4795,9 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"strongPassword123\"\n}"
+            },
+            "auth": {
+              "type": "noauth"
             }
           },
           "response": [
@@ -4909,7 +4915,10 @@
                 "refresh"
               ]
             },
-            "description": "Refresh access token using cookie (no auth)"
+            "description": "Refresh access token using cookie (no auth)",
+            "auth": {
+              "type": "noauth"
+            }
           },
           "response": [
             {


### PR DESCRIPTION
## Summary
- validate Postman collection and environment files against schemas
- confirm all API routes are represented exactly once in Postman collection
- mark public auth endpoints to bypass bearer authentication

## Testing
- `npx ajv-cli@3 validate -s /tmp/postman_collection_schema.json -d docs/api/postman_collection.json`
- `npx ajv-cli@3 validate -s /tmp/env_schema.json -d docs/api/postman_env.dev.json`
- `npx ajv-cli@3 validate -s /tmp/env_schema.json -d docs/api/postman_env.staging.json`
- `npx ajv-cli@3 validate -s /tmp/env_schema.json -d docs/api/postman_env.prod.json`
- `node route_check.js` *(script run inline to confirm each route appears exactly once in the collection)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7237e07988320a511d8f6cb288ef3