### PR TITLE
Add SensorReadingAlt entity for alternate moisture data

### DIFF
--- a/relations.txt
+++ b/relations.txt
@@ -27,3 +27,6 @@ User
 │  └─ permissions (M ↔ M via role_permissions) ↔ Permission
 └─ refreshTokens (1 → N) ← RefreshToken
    └─ user (N → 1, fk=user_id, onDelete=CASCADE)
+
+SensorReadingAlt
+└─ standalone entity (no relations defined)

--- a/src/database.ts
+++ b/src/database.ts
@@ -11,6 +11,7 @@ import { Alert } from "./entities/Alert";
 import { Permission } from "./entities/Permission";
 import { User } from "./entities/User";
 import { RefreshToken } from "./entities/RefreshToken";
+import { SensorReadingAlt } from "./entities/SensorReadingAlt";
 import { config } from "./config";
 
 export const AppDataSource = new DataSource({
@@ -28,6 +29,7 @@ export const AppDataSource = new DataSource({
     WorkerDeviceAssignment,
     ShiftAttendance,
     SensorReading,
+    SensorReadingAlt,
     WorkerHealthCondition,
     WorkerHealthIncident,
     Role,

--- a/src/entities/SensorReadingAlt.ts
+++ b/src/entities/SensorReadingAlt.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+/**
+ * Standalone sensor readings used for alternative ingestion pipelines.
+ * The entity is intentionally isolated so it can be linked to devices or
+ * environments in future migrations without impacting the main readings table.
+ */
+@Entity({ name: "sensor_readings_alt" })
+export class SensorReadingAlt {
+  /**
+   * Timestamp captured when the reading is inserted. Acts as the primary key
+   * for the alternate readings table.
+   */
+  @PrimaryColumn({ type: "timestamptz", default: () => "CURRENT_TIMESTAMP" })
+  timestamp!: Date;
+
+  /**
+   * Moisture level captured by the device. Stored as a decimal to allow
+   * precision for percentage based readings.
+   */
+  @Column({ type: "decimal", precision: 5, scale: 2 })
+  moisture!: number;
+}


### PR DESCRIPTION
## Summary
- create a standalone SensorReadingAlt TypeORM entity to capture alternate moisture readings
- register the new entity with the main data source and update the relations reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1c60d1908320a892ec6620d1ae37