### PR TITLE
Add alternate sensor readings table

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -91,6 +91,13 @@ CREATE TABLE IF NOT EXISTS sensor_readings (
     ON DELETE CASCADE
 );
 
+-- Alternate sensor readings (timestamp primary key)
+CREATE TABLE IF NOT EXISTS sensor_readings_alt (
+  "timestamp" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  moisture     NUMERIC(5,2) NOT NULL,
+  PRIMARY KEY ("timestamp")
+);
+
 -- Shift attendance
 CREATE TABLE IF NOT EXISTS shift_attendance (
   attendance_id  SERIAL PRIMARY KEY,

--- a/reset_db.sql
+++ b/reset_db.sql
@@ -16,6 +16,7 @@ BEGIN
       worker_health_conditions,
       shift_attendance,
       sensor_readings,
+      sensor_readings_alt,
       worker_device_assignments,
       devices,
       workers,

--- a/seed_db.sql
+++ b/seed_db.sql
@@ -213,6 +213,14 @@ FROM chosen_devices d
 CROSS JOIN t
 ON CONFLICT DO NOTHING;
 
+-- Sample alternate readings for integration tests
+INSERT INTO sensor_readings_alt("timestamp", moisture)
+VALUES
+  (now() - interval '5 minutes', 42.50),
+  (now() - interval '3 minutes', 47.25),
+  (now() - interval '1 minute', 44.75)
+ON CONFLICT ("timestamp") DO NOTHING;
+
 -- ~4k shifts: 200 workers × last 30 weekdays
 WITH w AS (
   SELECT worker_id FROM workers ORDER BY random() LIMIT 200

--- a/src/migrations/1758274230699-add_sensor_reading_alt.ts
+++ b/src/migrations/1758274230699-add_sensor_reading_alt.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSensorReadingAlt1758274230699 implements MigrationInterface {
+  name = "AddSensorReadingAlt1758274230699";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "sensor_readings_alt" (
+        "timestamp" TIMESTAMPTZ PRIMARY KEY DEFAULT now(),
+        "moisture" NUMERIC(5, 2) NOT NULL
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "sensor_readings_alt"`);
+  }
+}


### PR DESCRIPTION
## Summary
- add a migration that creates the sensor_readings_alt table with a timestamp primary key and numeric moisture column
- extend the manual database bootstrap scripts to create and reset the new table
- seed a few representative alternate readings for local development

## Testing
- `ACCESS_TOKEN_SECRET=test REFRESH_TOKEN_SECRET=test FRONTEND_ORIGIN=http://localhost DB_HOST=127.0.0.1 DB_PORT=5432 DB_USERNAME=karsu DB_PASSWORD=karsu DB_DATABASE=karsu npm run migration:run`


------
https://chatgpt.com/codex/tasks/task_e_68cd221ec38483208d4d992071b5250a